### PR TITLE
Spawn cars with a spare wheel

### DIFF
--- a/Missions/DayZCommunityOfflineMode.ChernarusPlus/core/modules/ComEditor/gui/GameMenu.c
+++ b/Missions/DayZCommunityOfflineMode.ChernarusPlus/core/modules/ComEditor/gui/GameMenu.c
@@ -160,7 +160,7 @@ class GameMenu extends PopupMenu
 	{
 		TStringArray attArr = {
 		"HeadlightH7", "HeadlightH7",
-		"HatchbackWheel", "HatchbackWheel", "HatchbackWheel", "HatchbackWheel",
+		"HatchbackWheel", "HatchbackWheel", "HatchbackWheel", "HatchbackWheel", "HatchbackWheel",
 		"CarBattery", "CarRadiator", "EngineBelt", "SparkPlug", "HatchbackHood",
 		"HatchbackTrunk", "HatchbackDoors_Driver", "HatchbackDoors_CoDriver",
 		};
@@ -172,7 +172,7 @@ class GameMenu extends PopupMenu
 	{
 		TStringArray attArr = {
 		"HeadlightH7", "HeadlightH7",
-		"CivSedanWheel", "CivSedanWheel", "CivSedanWheel", "CivSedanWheel",
+		"CivSedanWheel", "CivSedanWheel", "CivSedanWheel", "CivSedanWheel", "CivSedanWheel",
 		"CarBattery", "CarRadiator","EngineBelt", "SparkPlug","CivSedanHood",
 		"CivSedanTrunk", "CivSedanDoors_Driver","CivSedanDoors_CoDriver",
 		"CivSedanDoors_BackLeft", "CivSedanDoors_BackRight",
@@ -187,7 +187,7 @@ class GameMenu extends PopupMenu
 		"HeadlightH7", "HeadlightH7", "CarBattery", "CarRadiator", "SparkPlug", "Hatchback_02_Door_1_1",
 		"Hatchback_02_Door_1_2", "Hatchback_02_Door_2_1","Hatchback_02_Door_2_2",
 		"Hatchback_02_Trunk", "Hatchback_02_Hood", "Hatchback_02_Wheel", "Hatchback_02_Wheel",
-		"Hatchback_02_Wheel", "Hatchback_02_Wheel", "CivSedanDoors_BackRight",
+		"Hatchback_02_Wheel", "Hatchback_02_Wheel", "Hatchback_02_Wheel", "CivSedanDoors_BackRight",
 		};
 
 		SpawnVehicle( "Hatchback_02", attArr );
@@ -199,7 +199,7 @@ class GameMenu extends PopupMenu
 		"HeadlightH7", "HeadlightH7", "CarBattery", "CarRadiator", "SparkPlug", "Sedan_02_Hood",
 		"Sedan_02_Hood","Sedan_02_Trunk","Sedan_02_Door_1_1",
 		"Sedan_02_Door_2_1","Sedan_02_Door_1_2","Sedan_02_Door_2_2","Sedan_02_Wheel",
-		"Sedan_02_Wheel","Sedan_02_Wheel","Sedan_02_Wheel",
+		"Sedan_02_Wheel","Sedan_02_Wheel","Sedan_02_Wheel","Sedan_02_Wheel",
 		};
 
 		SpawnVehicle( "Sedan_02", attArr );

--- a/Missions/DayZCommunityOfflineMode.Enoch/core/modules/ComEditor/gui/GameMenu.c
+++ b/Missions/DayZCommunityOfflineMode.Enoch/core/modules/ComEditor/gui/GameMenu.c
@@ -156,11 +156,11 @@ class GameMenu extends PopupMenu
         SpawnVehicle( "Offroad_02", attArr );
     }
 
-	void SpawnHatchback() 
+	void SpawnHatchback()
 	{
 		TStringArray attArr = {
 		"HeadlightH7", "HeadlightH7",
-		"HatchbackWheel", "HatchbackWheel", "HatchbackWheel", "HatchbackWheel",
+		"HatchbackWheel", "HatchbackWheel", "HatchbackWheel", "HatchbackWheel", "HatchbackWheel",
 		"CarBattery", "CarRadiator", "EngineBelt", "SparkPlug", "HatchbackHood",
 		"HatchbackTrunk", "HatchbackDoors_Driver", "HatchbackDoors_CoDriver",
 		};
@@ -168,11 +168,11 @@ class GameMenu extends PopupMenu
 		SpawnVehicle( "OffroadHatchback", attArr );
 	}
 
-	void SpawnSedan() 
+	void SpawnSedan()
 	{
 		TStringArray attArr = {
 		"HeadlightH7", "HeadlightH7",
-		"CivSedanWheel", "CivSedanWheel", "CivSedanWheel", "CivSedanWheel",
+		"CivSedanWheel", "CivSedanWheel", "CivSedanWheel", "CivSedanWheel", "CivSedanWheel",
 		"CarBattery", "CarRadiator","EngineBelt", "SparkPlug","CivSedanHood",
 		"CivSedanTrunk", "CivSedanDoors_Driver","CivSedanDoors_CoDriver",
 		"CivSedanDoors_BackLeft", "CivSedanDoors_BackRight",
@@ -187,7 +187,7 @@ class GameMenu extends PopupMenu
 		"HeadlightH7", "HeadlightH7", "CarBattery", "CarRadiator", "SparkPlug", "Hatchback_02_Door_1_1",
 		"Hatchback_02_Door_1_2", "Hatchback_02_Door_2_1","Hatchback_02_Door_2_2",
 		"Hatchback_02_Trunk", "Hatchback_02_Hood", "Hatchback_02_Wheel", "Hatchback_02_Wheel",
-		"Hatchback_02_Wheel", "Hatchback_02_Wheel", "CivSedanDoors_BackRight",
+		"Hatchback_02_Wheel", "Hatchback_02_Wheel", "Hatchback_02_Wheel", "CivSedanDoors_BackRight",
 		};
 
 		SpawnVehicle( "Hatchback_02", attArr );
@@ -199,7 +199,7 @@ class GameMenu extends PopupMenu
 		"HeadlightH7", "HeadlightH7", "CarBattery", "CarRadiator", "SparkPlug", "Sedan_02_Hood",
 		"Sedan_02_Hood","Sedan_02_Trunk","Sedan_02_Door_1_1",
 		"Sedan_02_Door_2_1","Sedan_02_Door_1_2","Sedan_02_Door_2_2","Sedan_02_Wheel",
-		"Sedan_02_Wheel","Sedan_02_Wheel","Sedan_02_Wheel",
+		"Sedan_02_Wheel","Sedan_02_Wheel","Sedan_02_Wheel","Sedan_02_Wheel",
 		};
 
 		SpawnVehicle( "Sedan_02", attArr );

--- a/Missions/DayZCommunityOfflineMode.Namalsk/core/modules/ComEditor/gui/GameMenu.c
+++ b/Missions/DayZCommunityOfflineMode.Namalsk/core/modules/ComEditor/gui/GameMenu.c
@@ -161,7 +161,7 @@ class GameMenu extends PopupMenu
 	{
 		TStringArray attArr = {
 		"HeadlightH7", "HeadlightH7",
-		"HatchbackWheel", "HatchbackWheel", "HatchbackWheel", "HatchbackWheel",
+		"HatchbackWheel", "HatchbackWheel", "HatchbackWheel", "HatchbackWheel", "HatchbackWheel",
 		"CarBattery", "CarRadiator", "EngineBelt", "SparkPlug", "HatchbackHood",
 		"HatchbackTrunk", "HatchbackDoors_Driver", "HatchbackDoors_CoDriver",
 		};
@@ -169,11 +169,11 @@ class GameMenu extends PopupMenu
 		SpawnVehicle( "OffroadHatchback", attArr );
 	}
 
-	void SpawnSedan() 
+	void SpawnSedan()
 	{
 		TStringArray attArr = {
 		"HeadlightH7", "HeadlightH7",
-		"CivSedanWheel", "CivSedanWheel", "CivSedanWheel", "CivSedanWheel",
+		"CivSedanWheel", "CivSedanWheel", "CivSedanWheel", "CivSedanWheel", "CivSedanWheel",
 		"CarBattery", "CarRadiator","EngineBelt", "SparkPlug","CivSedanHood",
 		"CivSedanTrunk", "CivSedanDoors_Driver","CivSedanDoors_CoDriver",
 		"CivSedanDoors_BackLeft", "CivSedanDoors_BackRight",
@@ -188,7 +188,7 @@ class GameMenu extends PopupMenu
 		"HeadlightH7", "HeadlightH7", "CarBattery", "CarRadiator", "SparkPlug", "Hatchback_02_Door_1_1",
 		"Hatchback_02_Door_1_2", "Hatchback_02_Door_2_1","Hatchback_02_Door_2_2",
 		"Hatchback_02_Trunk", "Hatchback_02_Hood", "Hatchback_02_Wheel", "Hatchback_02_Wheel",
-		"Hatchback_02_Wheel", "Hatchback_02_Wheel", "CivSedanDoors_BackRight",
+		"Hatchback_02_Wheel", "Hatchback_02_Wheel", "Hatchback_02_Wheel", "CivSedanDoors_BackRight",
 		};
 
 		SpawnVehicle( "Hatchback_02", attArr );
@@ -200,7 +200,7 @@ class GameMenu extends PopupMenu
 		"HeadlightH7", "HeadlightH7", "CarBattery", "CarRadiator", "SparkPlug", "Sedan_02_Hood",
 		"Sedan_02_Hood","Sedan_02_Trunk","Sedan_02_Door_1_1",
 		"Sedan_02_Door_2_1","Sedan_02_Door_1_2","Sedan_02_Door_2_2","Sedan_02_Wheel",
-		"Sedan_02_Wheel","Sedan_02_Wheel","Sedan_02_Wheel",
+		"Sedan_02_Wheel","Sedan_02_Wheel","Sedan_02_Wheel","Sedan_02_Wheel",
 		};
 
 		SpawnVehicle( "Sedan_02", attArr );


### PR DESCRIPTION
This PR fixes an issue with Gunter spawning where due to the addition of a spare wheel in 1.19 the car is generated without a rear right wheel.
It also adds spare tires to all other cars.

Tested on a map Chernarus Plus.

![20221209155742_1](https://user-images.githubusercontent.com/16158349/206780942-a4c4d883-b76a-4f73-93c8-25253b3fb697.jpg)
![20221209155734_1](https://user-images.githubusercontent.com/16158349/206780970-063fd756-9da9-4a76-aecd-78735e8fd916.jpg)
![20221209155751_1](https://user-images.githubusercontent.com/16158349/206780983-3a3c3f39-f397-4671-b463-f79f2dff64c6.jpg)
![20221209155801_1](https://user-images.githubusercontent.com/16158349/206780992-df9b6d52-de6d-482d-8211-7cfe7215e87b.jpg)